### PR TITLE
Fix jsperf benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ var SimplexNoise = require('simplex-noise'),
 
 ## Benchmarks
 
-- [Comparison between 2D and 3D noise](http://jsperf.com/simplex-noise/2)
-- [Comparison with simplex implementation in three.js](http://jsperf.com/simplex-noise-comparison)
+- [Comparison between 2D and 3D noise](http://jsperf.com/simplex-noise/4)
+- [Comparison with simplex implementation in three.js](http://jsperf.com/simplex-noise-comparison/3)
 
 For development you can open `perf/index.html` and watch the console or run `node perf/benchmark.js` in a shell.
 There is also a rake task for comparing your current changes can also run `make compare`.


### PR DESCRIPTION
The jsperf benchmarks linked in the readme no longer work, since raw.github.com serves as text/plain and disables content type sniffing <script> inclusions to raw.github.com are denied by modern web browsers. 

Someone edited the benchmarks to fix this problem using rawgithub.com in revisions http://jsperf.com/simplex-noise/4 and http://jsperf.com/simplex-noise-comparison/3; this PR updates the readme to link to the updated URLs.
