### PR TITLE
Fixing falsy seed values

### DIFF
--- a/simplex-noise.js
+++ b/simplex-noise.js
@@ -41,7 +41,7 @@ Better rank ordering method by Stefan Gustavson in 2012.
     if (typeof randomOrSeed == 'function') {
       random = randomOrSeed;
     }
-    else if (randomOrSeed) {
+    else if (typeof randomOrSeed !== 'undefined') {
       random = alea(randomOrSeed);
     } else {
       random = Math.random;


### PR DESCRIPTION
If you set seed to zero or empty string, then SimplexNoise will generate random noise which might not be expected as the seed value was set. Now it will only be random if 'randomOrSeed' not set at all.