### PR TITLE
Export alea function

### DIFF
--- a/simplex-noise.ts
+++ b/simplex-noise.ts
@@ -442,7 +442,7 @@ The ALEA PRNG and masher code used by simplex-noise.js
 is based on code by Johannes Baagøe, modified by Jonas Wagner.
 See alea.md for the full license.
 */
-function alea(seed: string|number): RandomFn {
+export function alea(seed: string|number): RandomFn {
   let s0 = 0;
   let s1 = 0;
   let s2 = 0;


### PR DESCRIPTION
Export the `alea` function so other packages can use the same version as this library.