### PR TITLE
fix: #__PURE__ comment position

### DIFF
--- a/simplex-noise.ts
+++ b/simplex-noise.ts
@@ -28,14 +28,14 @@ Better rank ordering method by Stefan Gustavson in 2012.
  */
 
 
-// these #__PURE__ comments help uglifyjs with dead code removal
-// 
-const F2 = /*#__PURE__*/ 0.5 * (Math.sqrt(3.0) - 1.0);
-const G2 = /*#__PURE__*/ (3.0 - Math.sqrt(3.0)) / 6.0;
+// these __PURE__ comments help uglifyjs with dead code removal
+//
+const F2 = 0.5 * (/*#__PURE__*/Math.sqrt(3.0) - 1.0);
+const G2 = (3.0 - /*#__PURE__*/Math.sqrt(3.0)) / 6.0;
 const F3 = 1.0 / 3.0;
 const G3 = 1.0 / 6.0;
-const F4 = /*#__PURE__*/ (Math.sqrt(5.0) - 1.0) / 4.0;
-const G4 = /*#__PURE__*/ (5.0 - Math.sqrt(5.0)) / 20.0;
+const F4 = (/*#__PURE__*/Math.sqrt(5.0) - 1.0) / 4.0;
+const G4 = (5.0 - /*#__PURE__*/Math.sqrt(5.0)) / 20.0;
 
 // I'm really not sure why this | 0 (basically a coercion to int)
 // is making this faster but I get ~5 million ops/sec more on the


### PR DESCRIPTION
Make sure annotation precede a function/constructor call.

Closes #66