### PR TITLE
feat: make sqrt constants

### DIFF
--- a/simplex-noise.ts
+++ b/simplex-noise.ts
@@ -30,12 +30,14 @@ Better rank ordering method by Stefan Gustavson in 2012.
 
 // these __PURE__ comments help uglifyjs with dead code removal
 //
-const F2 = 0.5 * (/*#__PURE__*/Math.sqrt(3.0) - 1.0);
-const G2 = (3.0 - /*#__PURE__*/Math.sqrt(3.0)) / 6.0;
+const SQRT3 = /*#__PURE__*/ Math.sqrt(3.0);
+const SQRT5 = /*#__PURE__*/ Math.sqrt(5.0);
+const F2 = 0.5 * (SQRT3 - 1.0);
+const G2 = (3.0 - SQRT3) / 6.0;
 const F3 = 1.0 / 3.0;
 const G3 = 1.0 / 6.0;
-const F4 = (/*#__PURE__*/Math.sqrt(5.0) - 1.0) / 4.0;
-const G4 = (5.0 - /*#__PURE__*/Math.sqrt(5.0)) / 20.0;
+const F4 = (SQRT5 - 1.0) / 4.0;
+const G4 = (5.0 - SQRT5) / 20.0;
 
 // I'm really not sure why this | 0 (basically a coercion to int)
 // is making this faster but I get ~5 million ops/sec more on the


### PR DESCRIPTION
The previous PR actually only fixed 2 of the 4 warnings in rollup. Somehow the REPL online is not reporting them (as you can see from the links [in that comment earlier](https://github.com/jwagner/simplex-noise.js/issues/66#issuecomment-2220065228)) although I am using the same 4.18.1 rollup version locally.
So apologies for the second PR in a row, the repl wasn't enough 😕 But I have tested with a real use case now.

Here I have extracted the two sqrt calls into const which has two benefits:

- performance/size: saves a few bytes when tested with terser (when using noise 2D and noise 4D, noise 3D is not using the sqrts' so nothing more is eliminated)
- actually fix rollup annotation warnings